### PR TITLE
#1: fixing the compilation order of library dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS=-std=gnu99 -O3 -Wall
 all: $(PROG)
 
 $(PROG): $(PROG).o
-	$(CC) -o $(PROG) -lpigpio -lrt $<
+	$(CC) -o $(PROG) $< -lpigpio -lrt
 
 clean:
 	rm -f $(PROG) *.o


### PR DESCRIPTION
Works now, shown as follows in vivado 2025.1

![working_jtag](https://github.com/user-attachments/assets/fb107ee2-80d9-4288-b945-6b34ea0e431d)
